### PR TITLE
Fix CI test failure for CLI package

### DIFF
--- a/packages/blogue-cli/package.json
+++ b/packages/blogue-cli/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc && chmod +x bin/blogue.js",
     "dev": "tsc --watch",
-    "test": "vitest",
+    "test": "vitest run --passWithNoTests",
     "lint": "eslint src && tsc --noEmit",
     "lint:fix": "eslint src --fix"
   },


### PR DESCRIPTION
  - Add --passWithNoTests flag to vitest to handle empty test suite
  - Prevents CI failure when no test files exist in CLI package